### PR TITLE
Update notifi SDK to 0.0.1 

### DIFF
--- a/components/NotificationsCard.tsx
+++ b/components/NotificationsCard.tsx
@@ -95,7 +95,7 @@ const NotificationsCard = ({ proposal }: { proposal?: Option<Proposal> }) => {
 
   const getTargetGroups = useGetTargetGroups()
   const getExistingTargetGroup = useCallback(() => {
-    getTargetGroups({})
+    getTargetGroups()
       .then((resp) => {
         const targetGroup = resp[0]
         console.log(targetGroup)
@@ -128,7 +128,7 @@ const NotificationsCard = ({ proposal }: { proposal?: Option<Proposal> }) => {
 
   const getSourceGroups = useGetSourceGroups()
   const getSourceGroup = useCallback(() => {
-    getSourceGroups({})
+    getSourceGroups()
       .then((resp) => {
         const sourceGroup = resp[0]
         console.log(sourceGroup)
@@ -141,7 +141,7 @@ const NotificationsCard = ({ proposal }: { proposal?: Option<Proposal> }) => {
 
   const getFilters = useGetFilters()
   const getFilter = useCallback(() => {
-    getFilters({})
+    getFilters()
       .then((resp) => {
         const filter = resp[0]
         console.log(filter)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@heroicons/react": "^1.0.1",
     "@metaplex/js": "^4.10.1",
     "@nfteyez/sol-rayz": "^0.8.0",
-    "@notifi-network/notifi-react-hooks": "^0.0.1-alpha.13",
+    "@notifi-network/notifi-react-hooks": "^0.0.1",
     "@project-serum/anchor": "^0.10.0",
     "@project-serum/borsh": "^0.2.2",
     "@project-serum/common": "^0.0.1-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,10 +1300,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@notifi-network/notifi-react-hooks@^0.0.1-alpha.13":
-  version "0.0.1-alpha.13"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.0.1-alpha.13.tgz#812fc591665062871bd1dfdf35bc0b11f4b1e6ca"
-  integrity sha512-YFVD7R/0YknCw9Q7iW6qE/s5WN39m3DNAcTW3GHYBtlywbmNwuDd+C7Xiq3vP6IoSxBt9EdOj5xXUjvXzpLO9A==
+"@notifi-network/notifi-react-hooks@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.0.1.tgz#3c48b137553da088528b3cd870a811e74e153062"
+  integrity sha512-Dcaks9DtAVNdapaE8ku4qU79/R7nBPQOWse4DVCddmx3dMcYLUVCQbd0Lyp6hAGYBNNoQ5nj+MZvm9uLczhm1g==
   dependencies:
     axios "^0.26.0"
     react "^17.0.2"


### PR DESCRIPTION
This is the main release channel

The new version has zero-parameter versions of some operations.

It also includes a fix for the storage key